### PR TITLE
Add support for no-cache builds and restarting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ docker-start:
 	@docker compose build
 	@docker compose watch ui
 
+docker-start-no-cache:
+  # Builds the docker images based on the `docker-compose.yaml` file with no cache, and starts new containers
+	@docker-compose build --no-cache
+	@docker-compose down
+	@docker-compose up -d --force-recreate
+	@docker compose watch ui
+
 docker-stop:
   # Stops the running containers associated with the `docker-compose.yaml` file
 	@docker compose down
@@ -45,9 +52,20 @@ start-dev:
 		delete-override \
 		start
 
+start-dev-no-cache:
+	@${MAKE} \
+		delete-override \
+		docker-start-no-cache
+
 start-dev-rancher:
 	@${MAKE} \
 	  create-override \
+		start
+
+restart-dev:
+	@${MAKE} \
+		delete-override \
+		docker-stop \
 		start
 
 stop-dev:


### PR DESCRIPTION
- Added `docker-start-no-cache`:
  - A new Makefile target that builds Docker images without using the cache (`--no-cache`) and recreates the containers with `--force-recreate`. This ensures that the most recent code changes are always applied.
  - This includes stopping and removing the current containers and starting new ones.

- Added `start-dev-no-cache`:
  - This target now leverages the newly added `docker-start-no-cache` to allow for development environments that require fresh builds without cached layers.

- Added `restart-dev`:
  - Simplified restart flow by ensuring containers are stopped and then restarted using the updated images and configurations, including deleting the override file if it exists.