### PR TITLE
Feature/keycloak db and pgadmin4 docker access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,10 @@ services:
       KEYCLOAK_ADMIN: "admin"
       KEYCLOAK_ADMIN_PASSWORD: "password"
       KC_PROXY: "edge"
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres_dev:5432/postgres
+      KC_DB_USERNAME: admin
+      KC_DB_PASSWORD: root
       PROXY_ADDRESS_FORWARDING: "true"
     depends_on:
       postgres_dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,20 @@ services:
     restart: unless-stopped
     networks:
       - starter-network
+  
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: password
+      PGADMIN_LISTEN_PORT: 8001
+    ports: 
+      - "8001:8001"
+    depends_on:
+      - postgres_dev
+    networks:
+      - starter-network
 
   ui: #note that to run this use ```docker-compose watch web```
     image: starter_app:frontend


### PR DESCRIPTION
Moved Keycloak Database from Defaulted H2 to postgres_dev container in postgres database
Added pgadmin4 to Docker to allowing a GUI for viewing the postgres_dev database

API for Postman also works after removing client authentication setting and toggling on Direct access grants in zeus-app > Clients > starter-app (needs to be fixed in future pr)
This means that utilizing KeyCloak for Authentication works with Bearer JWT though username/pasword authentication 
