### PR TITLE
Removing import React

### DIFF
--- a/ui/src/components/custom/search/filtersInterface.tsx
+++ b/ui/src/components/custom/search/filtersInterface.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 export default class filtersInterface extends Component {
   render() {

--- a/ui/src/components/custom/search/matrixCardLg.tsx
+++ b/ui/src/components/custom/search/matrixCardLg.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@mui/material'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 export default class matrixCardLg extends Component {
   render() {

--- a/ui/src/components/custom/search/matrixExplorer.tsx
+++ b/ui/src/components/custom/search/matrixExplorer.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 export default class matrixExplorer extends Component {
   render() {


### PR DESCRIPTION
Three files, “filesInterface.tsx”, “matrixCardLg.tsx”, and “matrixExplorer.tsx”, had an import statement at the top that was unnecessary and therefore causing some build problems with “make start-dev”.
The line “import React from ‘react’” is not necessary to include in any React 17 versions or up.

Scrum board ticket: CARVER-95