### PR TITLE
PgAdmin4 Auto Connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,10 @@ services:
       - starter-network
 
   pgadmin:
-    image: dpage/pgadmin4
+    build:
+      context: .
+      dockerfile: docker/dockerfile-pgadmin
     container_name: pgadmin
-    environment:
-      PGADMIN_DEFAULT_EMAIL: admin@admin.com
-      PGADMIN_DEFAULT_PASSWORD: password
-      PGADMIN_LISTEN_PORT: 8001
     ports:
       - "8001:8001"
     depends_on:

--- a/docker/dockerfile-pgadmin
+++ b/docker/dockerfile-pgadmin
@@ -1,0 +1,12 @@
+FROM dpage/pgadmin4:latest
+
+ENV PGADMIN_DEFAULT_EMAIL=admin@admin.com \
+    PGADMIN_DEFAULT_PASSWORD=password \
+    PGADMIN_LISTEN_PORT=8001 \
+    PGADMIN_CONFIG_SERVER_MODE=False \
+    PGADMIN_SERVER_JSON_FILE=/servers.json
+
+# Note the "docker/" in front of servers.json
+COPY docker/servers.json /servers.json
+
+EXPOSE 8001

--- a/docker/servers.json
+++ b/docker/servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "postgres_dev",
+      "Group": "Servers",
+      "Host": "postgres_dev",
+      "Port": 5432,
+      "Username": "admin",
+      "Password": "root",
+      "SSLMode": "prefer",
+      "MaintenanceDB": "starter_app"
+    }
+  }
+}


### PR DESCRIPTION
docker‐compose.yml

Replaces the direct dpage/pgadmin4 image reference with a custom build. Points to a new docker/dockerfile‐pgadmin and removes the hardcoded pgAdmin environment variables. dockerfile‐pgadmin

Inherits from dpage/pgadmin4:latest.
Sets default credentials (email/password) and pgAdmin configuration via ENV variables. Copies in a servers.json file at build time so pgAdmin comes preconfigured for our Postgres instance. Exposes port 8001.
servers.json

Defines a preconfigured connection to our existing Postgres DB (postgres_dev) with the correct host, port, username, and database name. Allows pgAdmin to “see” the database as soon as the container is up and running.