### PR TITLE
Implement JWT-based user upsert and role extraction

### DIFF
--- a/backend/src/main/java/com/fmc/starterApp/controllers/User2Controller.java
+++ b/backend/src/main/java/com/fmc/starterApp/controllers/User2Controller.java
@@ -3,12 +3,15 @@ package com.fmc.starterApp.controllers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fmc.starterApp.models.dto.JWTInfoDTO;
 import com.fmc.starterApp.models.entity.User2;
 import com.fmc.starterApp.services.User2Service;
 
@@ -40,4 +43,16 @@ public class User2Controller {
         }
     }
 
+    @GetMapping("/whoami")
+    public ResponseEntity<JWTInfoDTO> whoAmI(@AuthenticationPrincipal Jwt jwt) {
+        JWTInfoDTO jwtInfo = user2Service.extractJwtInfo(jwt);
+        return ResponseEntity.ok(jwtInfo);
+    }
+
+    // New endpoint: upsert user based on JWT information.
+    @GetMapping("/whoami-upsert")
+    public ResponseEntity<User2> whoAmIUpsert(@AuthenticationPrincipal Jwt jwt) {
+        User2 user = user2Service.upsertUser(jwt);
+        return ResponseEntity.ok(user);
+    }
 }

--- a/backend/src/main/java/com/fmc/starterApp/models/dto/JWTInfoDTO.java
+++ b/backend/src/main/java/com/fmc/starterApp/models/dto/JWTInfoDTO.java
@@ -1,0 +1,18 @@
+package com.fmc.starterApp.models.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Builder
+@Data
+public class JWTInfoDTO {
+    String keycloakID;
+    String sessionID;
+    boolean emailVerified;
+    String username;
+    String email;
+    List<String> starterAppRole;
+    List<String> accountRole;
+}

--- a/backend/src/main/java/com/fmc/starterApp/repositories/User2Repository.java
+++ b/backend/src/main/java/com/fmc/starterApp/repositories/User2Repository.java
@@ -1,8 +1,11 @@
 package com.fmc.starterApp.repositories;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.fmc.starterApp.models.entity.User2;
 
 public interface User2Repository extends JpaRepository<User2, Long> {
+    Optional<User2> findByKeycloakId(String keycloakId);
 }

--- a/backend/src/main/java/com/fmc/starterApp/services/User2Service.java
+++ b/backend/src/main/java/com/fmc/starterApp/services/User2Service.java
@@ -1,10 +1,18 @@
 package com.fmc.starterApp.services;
 
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fmc.starterApp.models.dto.JWTInfoDTO;
 import com.fmc.starterApp.models.dto.User2DTO;
 import com.fmc.starterApp.models.entity.User2;
 import com.fmc.starterApp.repositories.User2Repository;
@@ -22,11 +30,93 @@ public class User2Service {
         return user2;
     }
 
+    public User2 upsertUser(Jwt jwt) {
+        // Extract the keycloakId (using "sub" as the keycloak id), username, and email from the JWT.
+        String keycloakId = jwt.getClaim("sub");
+        String username = jwt.getClaim("preferred_username");
+        String email = jwt.getClaim("email");
+
+        Optional<User2> optionalUser = user2Repository.findByKeycloakId(keycloakId);
+
+        if (optionalUser.isPresent()) {
+            // User exists - update username and email if necessary.
+            User2 existingUser = optionalUser.get();
+            boolean updated = false;
+
+            if (!existingUser.getUsername().equals(username)) {
+                existingUser.setUsername(username);
+                updated = true;
+            }
+            if (!existingUser.getEmail().equals(email)) {
+                existingUser.setEmail(email);
+                updated = true;
+            }
+            if (updated) {
+                return user2Repository.save(existingUser);
+            } else {
+                return existingUser;
+            }
+        } else {
+            // User does not exist - create a new user.
+            User2 newUser = new User2();
+            newUser.setKeycloakId(keycloakId);
+            newUser.setUsername(username);
+            newUser.setEmail(email);
+            return user2Repository.save(newUser);
+        }
+    }
+
     public User2DTO getUserInfo() {
         List<User2> users = user2Repository.findAll();
         return User2DTO.builder()
                 .users(users)
                 .totalUsers(users.size())
+                .build();
+    }
+
+    public String getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof JwtAuthenticationToken) {
+            Jwt jwt = ((JwtAuthenticationToken) authentication).getToken();
+            return jwt.getClaimAsString("sub");
+        }
+        return null;  // or throw an exception if not authenticated
+    }
+
+   public JWTInfoDTO extractJwtInfo(Jwt jwt) {
+        // Extract basic claims
+        String keycloakID = jwt.getClaim("sub");
+        String sessionID = jwt.getClaim("sid"); // or "session_state" based on your JWT
+        Boolean emailVerified = jwt.getClaim("email_verified");
+        String username = jwt.getClaim("preferred_username");
+        String email = jwt.getClaim("email");
+
+        // Extract roles from the "resource_access" claim
+        List<String> starterAppRole = new ArrayList<>();
+        List<String> accountRole = new ArrayList<>();
+        Map<String, Object> resourceAccess = jwt.getClaim("resource_access");
+        if (resourceAccess != null) {
+            // Extract roles for "starter-app"
+            Map<String, Object> starterApp = (Map<String, Object>) resourceAccess.get("starter-app");
+            if (starterApp != null && starterApp.get("roles") instanceof List) {
+                starterAppRole = (List<String>) starterApp.get("roles");
+            }
+            // Extract roles for "account"
+            Map<String, Object> account = (Map<String, Object>) resourceAccess.get("account");
+            if (account != null && account.get("roles") instanceof List) {
+                accountRole = (List<String>) account.get("roles");
+            }
+        }
+
+        // Build and return the JWTInfoDTO
+        return JWTInfoDTO.builder()
+                .keycloakID(keycloakID)
+                .sessionID(sessionID)
+                .emailVerified(emailVerified)
+                .username(username)
+                .email(email)
+                .starterAppRole(starterAppRole)
+                .accountRole(accountRole)
                 .build();
     }
 }


### PR DESCRIPTION
feat: Implement JWT-based user upsert and role extraction

- Added `JWTInfoDTO` to encapsulate JWT claims, including keycloak ID, session ID, email, username, and roles.
- Updated `User2Controller`:
  - Refactored `/whoami` endpoint to return a structured `JWTInfoDTO` instead of a raw principal.
  - Added `/whoami-upsert` endpoint to upsert users based on JWT claims.
  - Removed redundant `/userinfo` and `/current` endpoints.
- Enhanced `User2Service`:
  - Implemented `upsertUser` method to create or update users based on JWT claims.
  - Introduced `extractJwtInfo` method to parse JWT and extract roles from `resource_access`.
- Updated `User2Repository` with a new query method `findByKeycloakId(String keycloakId)`.
- Refactored `User2Service` to support role extraction from JWT's `resource_access` claim.