### PR TITLE
Added Get CarverMatrix By Id

### DIFF
--- a/backend/src/main/java/com/fmc/starterApp/controllers/CarverMatrixController.java
+++ b/backend/src/main/java/com/fmc/starterApp/controllers/CarverMatrixController.java
@@ -1,15 +1,25 @@
 package com.fmc.starterApp.controllers;
 
-import com.fmc.starterApp.models.entity.CarverMatrix;
-import com.fmc.starterApp.services.CarverMatrixService;
-import lombok.AllArgsConstructor;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
+import com.fmc.starterApp.models.entity.CarverMatrix;
+import com.fmc.starterApp.services.CarverMatrixService;
+
+import lombok.AllArgsConstructor;
 
 @RestController
 @AllArgsConstructor
@@ -17,7 +27,18 @@ import java.util.Map;
 public class CarverMatrixController {
 
     @Autowired
-    private CarverMatrixService carverMatrixService;
+    CarverMatrixService carverMatrixService;
+
+    @GetMapping("/{matrixId}")
+    public ResponseEntity<?> getCarverMatrixByCarverId(@PathVariable Long matrixId) {
+        try {
+            CarverMatrix matrix = carverMatrixService.getMatrixById(matrixId);
+            return ResponseEntity.ok(matrix);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
 
     @GetMapping("/host")
     public ResponseEntity<?> getMatricesByHost(@RequestParam Long userId) {

--- a/backend/src/main/java/com/fmc/starterApp/repositories/CarverMatrixRepository.java
+++ b/backend/src/main/java/com/fmc/starterApp/repositories/CarverMatrixRepository.java
@@ -1,13 +1,14 @@
 package com.fmc.starterApp.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import com.fmc.starterApp.models.entity.CarverMatrix;
 
-import java.util.List;
+import com.fmc.starterApp.models.entity.CarverMatrix;
 
 @Repository
 public interface CarverMatrixRepository extends JpaRepository<CarverMatrix, Long>, JpaSpecificationExecutor<CarverMatrix> {
@@ -17,4 +18,7 @@ public interface CarverMatrixRepository extends JpaRepository<CarverMatrix, Long
 
     @Query(value = "SELECT * FROM carver_matrices WHERE CAST(:userId AS text) = ANY(participants)", nativeQuery = true)
     List<CarverMatrix> findByParticipant(@Param("userId") String userId);
+
+    CarverMatrix findFirstByMatrixId(Long matrixId);
+
 }

--- a/backend/src/main/java/com/fmc/starterApp/services/CarverMatrixService.java
+++ b/backend/src/main/java/com/fmc/starterApp/services/CarverMatrixService.java
@@ -1,21 +1,23 @@
 package com.fmc.starterApp.services;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.Hibernate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.fmc.starterApp.models.entity.CarverItem;
 import com.fmc.starterApp.models.entity.CarverMatrix;
 import com.fmc.starterApp.models.entity.User2;
 import com.fmc.starterApp.repositories.CarverMatrixRepository;
 import com.fmc.starterApp.repositories.User2Repository;
-import lombok.AllArgsConstructor;
-import org.hibernate.Hibernate;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.data.jpa.domain.Specification;
 
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
 import jakarta.persistence.criteria.Predicate;
+import lombok.AllArgsConstructor;
 
 @Service
 @AllArgsConstructor
@@ -39,6 +41,16 @@ public class CarverMatrixService {
         matrices.forEach(matrix -> Hibernate.initialize(matrix.getItems()));
         return matrices;
     }
+
+    @Transactional
+    public CarverMatrix getMatrixById(Long matrixId) {
+        CarverMatrix matrix = carverMatrixRepository.findFirstByMatrixId(matrixId);
+        if (matrix != null) {
+            Hibernate.initialize(matrix.getItems());
+        }
+        return matrix;
+    }
+
 
     public CarverMatrix createCarverMatrix(CarverMatrix matrix, Long userId) {
         User2 user = user2Repository.findById(userId)


### PR DESCRIPTION
feat: Add new CarverMatrix endpoint to retrieve matrix by ID

- Implemented a new GET endpoint in `CarverMatrixController` to fetch a CarverMatrix by matrixId
- Added `findBySrmId(Long matrixId)` in `CarverMatrixRepository` for efficient retrieval
- Updated `CarverMatrixService` with a `getMatrixById(Long matrixId)` method to orchestrate data access
- Refactored imports and improved error handling where necessary